### PR TITLE
Remove project status section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ![Reddit RSS Generator Interface](images/reddit_rss_generator.png)
 
-## ✅ Project Status: COMPLETED
-
 A lightweight, single-file tool that runs locally in your browser to generate RSS feed URLs for Reddit subreddits. No containers, no server setup, no dependencies - just open the HTML file and start generating URLs.
 
 ## 🔍 Use Case


### PR DESCRIPTION
## Changes

This PR removes the "Project Status: COMPLETED" section from the README as it is not necessary in a README file.

This change makes the documentation more professional and follows standard README conventions.

@RyansOpenSauceRice can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8908b44bebc44c029e946e9a8a59f50a)